### PR TITLE
Remove EPD dependencies from appman_gui

### DIFF
--- a/modules/ApplicationControl/appman.py
+++ b/modules/ApplicationControl/appman.py
@@ -142,6 +142,8 @@ def _detect_type(module_file, fail_hard=False):
         return 'python'
     elif ext == '.m':
         return 'MATLAB'
+    elif ext == '.exe':
+        return 'exe'
     elif ext == '':
         return 'exe'
     else:
@@ -247,12 +249,12 @@ def _compose_line(module, app, config):
             cmd = 'start'
             if use_screen == True:
                 cmd += ' /MIN '
-            cmdline_items = [killtag, cmd, mtype, '"%s"' % full_mfile, '"%s"' % conf_file, server]
+            cmdline_items = [killtag, cmd, "python", '"%s"' % full_mfile, '"%s"' % conf_file, server]
 
         else:
-            cmdline_items = [killtag, mtype, full_mfile, conf_file, server]
+            cmdline_items = [killtag, "python", full_mfile, conf_file, server]
         
-    if mtype == 'MATLAB':
+    elif mtype == 'MATLAB':
         if os_name == "Windows":
             cd = 'cd /D "%s" && ' % directory
         else:
@@ -264,7 +266,7 @@ def _compose_line(module, app, config):
 
         if os_name == "Windows":
         
-            cmd = 'start matlab -nosplash'
+            cmd = 'start matlab -nosplash -nodesktop'
             if use_screen == True:
                 cmd += ' -minimize'
         
@@ -272,8 +274,22 @@ def _compose_line(module, app, config):
         else:
             cmdline_items = [cd, matlab_env, killtag, 'matlab-shell', mline]
 
-    if mtype == 'exe':
-        cmdline_items = [killtag, module, conf_file, server]
+    elif mtype == 'exe':
+
+        if os_name == "Windows":
+            full_mfile = os.path.join(directory, mfile)
+
+            cmd = 'start'
+            if use_screen == True:
+                cmd += ' /MIN '
+
+            if conf_file.lower() == "none":
+                conf_file = ""
+
+            cmdline_items = [killtag, cmd, '"%s"' % mfile, '"%s"' % full_mfile, '"%s"' % conf_file, server]
+    
+        else:
+            cmdline_items = [killtag, module, conf_file, server]
 
     cmdline = ' '.join(cmdline_items)
 

--- a/modules/ApplicationControl/appman_gui.py
+++ b/modules/ApplicationControl/appman_gui.py
@@ -14,11 +14,11 @@ import re
 import wx
 import platform
 
-from enthought.traits.api import HasTraits, Bool, Enum, Float, Str, List, File, \
+from traits.api import HasTraits, Bool, Enum, Float, Str, List, File, \
      Button, String, Instance
-from enthought.traits.ui.api import Handler, View, Item, UItem, StatusItem, \
+from traitsui.api import Handler, View, Item, UItem, StatusItem, \
      Group, HGroup, VGroup, spring, EnumEditor, ButtonEditor, TextEditor, InstanceEditor
-from enthought.traits.ui.wx.animated_gif_editor import AnimatedGIFEditor
+from traitsui.wx.animated_gif_editor import AnimatedGIFEditor
 from output_stream import OutputStream
 
 
@@ -614,7 +614,7 @@ class SessionManager(HasTraits):
                     # ------------------------------------------------------------------------
                     self.update_status("Pinging modules..")
 
-                    num_retries = 30
+                    num_retries = 50
                     self.module_id_list = {};
                     module_list = []
                     for h in hosts.keys():
@@ -801,7 +801,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     print("Using MM IP=%s" % (args.mm_ip))
 
-    app = wx.PySimpleApp()
+    app = wx.App(False)
     frame = MainWindow(args.mm_ip)
     app.MainLoop()
 

--- a/modules/ApplicationControl/confman.py
+++ b/modules/ApplicationControl/confman.py
@@ -2,9 +2,9 @@ import sys
 import os
 import wx
 import re
-from enthought.traits.api import Str, HasTraits, DelegatesTo, List, This, \
+from traits.api import Str, HasTraits, DelegatesTo, List, This, \
                                 Dict, Any, Instance, Enum
-from enthought.traits.ui.api import View, Item, TreeEditor, TreeNode, Group
+from traitsui.api import View, Item, TreeEditor, TreeNode, Group
 import subprocess
 from argparse import ArgumentParser
 from ConfigParser import SafeConfigParser
@@ -232,6 +232,6 @@ if __name__ == "__main__":
                   #'PVA'    : args.pva_file_name,
                   'appman' : args.appman_file_name}
 
-    app = wx.PySimpleApp()
+    app = wx.App(False)
     frame = MainWindow(None, wx.ID_ANY, args.config_dir, args.session, root_files)
     app.MainLoop()

--- a/modules/ApplicationControl/output_stream.py
+++ b/modules/ApplicationControl/output_stream.py
@@ -1,8 +1,8 @@
 """Contains the class OutputStream, a HasTraits file-like text buffer."""
 
-from enthought.traits.api import HasTraits, Str, Bool, Trait, Int
-from enthought.traits.ui.api import View, UItem, TextEditor, Handler
-from enthought.etsconfig.api import ETSConfig
+from traits.api import HasTraits, Str, Bool, Trait, Int
+from traitsui.api import View, UItem, TextEditor, Handler
+from traits.etsconfig.api import ETSConfig
 
 
 DEFAULT_MAX_LEN = 8000


### PR DESCRIPTION
appman_gui no longer requires the Enthought Python Distribution, as long as the following packages were installed: traits, pyface, traitsui, and wxPython. Note that wx.PySimpleApp() was replaced by wx.App(False) for wxPython versions 2.9 and 3.0. More changes would be required for using wxPython 4.0 and newer.